### PR TITLE
Support different accounts

### DIFF
--- a/src/pymonzo/accounts/enums.py
+++ b/src/pymonzo/accounts/enums.py
@@ -12,6 +12,9 @@ class MonzoAccountType(str, Enum):
 
     UK_PREPAID = "uk_prepaid"
     UK_RETAIL = "uk_retail"
+    UK_REWARDS = "uk_rewards"
+    UK_BUSINESS = "uk_business"
+    UK_LOAN = "uk_loan"
 
 
 class MonzoAccountCurrency(str, Enum):


### PR DESCRIPTION
Monzo has support for different account types, which cause pymonzo to fail. Adding these seemed to fix the issue for my experiments.